### PR TITLE
Use exact Zendesk `1.13.0` ConversationKit `1.10.0` CoreUtilities `1.4.0`

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "zendesk/sdk_conversation_kit_ios" == 1.10.0
 github "zendesk/sdk_ui_components_ios" ~> 2.8.0
 github "zendesk/sdk_zendesk_ios" == 1.13.0
-github "zendesk/sdk_core_utilities_ios" ~> 1.4.0
+github "zendesk/sdk_core_utilities_ios" == 1.4.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "zendesk/sdk_conversation_kit_ios" ~> 1.10.0
+github "zendesk/sdk_conversation_kit_ios" == 1.10.0
 github "zendesk/sdk_ui_components_ios" ~> 2.8.0
-github "zendesk/sdk_zendesk_ios" ~> 1.13.0
+github "zendesk/sdk_zendesk_ios" == 1.13.0
 github "zendesk/sdk_core_utilities_ios" ~> 1.4.0

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
                  .exact("1.13.0")),
         .package(name: "ZendeskSDKCoreUtilities",
                  url: "https://github.com/zendesk/sdk_core_utilities_ios",
-                 from: "1.4.0")
+                 .exact("1.4.0"))
     ],
     targets: [
         .binaryTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,13 @@ let package = Package(
     dependencies: [
         .package(name: "ZendeskSDKConversationKit",
                  url: "https://github.com/zendesk/sdk_conversation_kit_ios",
-                 from: "1.10.0"),
+                 .exact("1.10.0")),
         .package(name: "ZendeskSDKUIComponents",
                  url: "https://github.com/zendesk/sdk_ui_components_ios",
                  from: "2.8.0"),
         .package(name: "ZendeskSDK",
                  url: "https://github.com/zendesk/sdk_zendesk_ios",
-                 from: "1.13.0"),
+                 .exact("1.13.0")),
         .package(name: "ZendeskSDKCoreUtilities",
                  url: "https://github.com/zendesk/sdk_core_utilities_ios",
                  from: "1.4.0")


### PR DESCRIPTION
Use exact Zendesk `1.13.0`, ConversationKit `1.10.0` and CoreUtilities `1.4.0` versions for Swift Package Manager and Carthage.